### PR TITLE
Update claims.json to add apache daffodil

### DIFF
--- a/claims.json
+++ b/claims.json
@@ -2028,6 +2028,7 @@
   "org.apache.beam beam-runners-flink_*-examples": "scalacenter/scaladex-void",
   "org.apache.beam beam-runners-flink*": "scalacenter/scaladex-void",
   "org.apache.beam beam-runners-flink*-examples": "scalacenter/scaladex-void",
+  "org.apache.daffodil *": "scalacenter/scaladex-void",
   "org.apache.distributedlog distributedlog*": "scalacenter/scaladex-void",
   "org.apache.ignite ignite-scalar*": "scalacenter/scaladex-void",
   "org.apache.ignite ignite-spark*": "scalacenter/scaladex-void",


### PR DESCRIPTION
Honestly, I am just guessing as to what this entry is supposed to contain. 
Hoping for help in adding this very large scala project (apache daffodil (incubating)) to scaladex.  
Apache daffodil is available from maven central now (version 2.1.0).